### PR TITLE
specify source files to preprocess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,17 @@ PREPROCESS = python tools/preprocess-1.1.0/lib/preprocess.py -s \
              -D VERSION=$(VERSION) \
              -D ASMJS_TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) \
              $(NULL)
-PREPROCESS_SRCS = $(shell find . -name "*.in" -not -path config/build.js.in)
+PREPROCESS_SRCS = \
+	./bindings.ts.in \
+	./config.ts.in \
+	./index.html.in \
+	./index.js.in \
+	./main.html.in \
+	./manifest.webapp.in \
+	./native.js.in \
+	./style/main.css.in \
+	./tests/index.js.in \
+	$(NULL)
 PREPROCESS_DESTS = $(PREPROCESS_SRCS:.in=)
 
 all: config-build java jasmin tests j2me shumway aot bench/benchmark.jar bld/main-all.js


### PR DESCRIPTION
@marco-c, @brendandahl: Both Boehm.js and the Emscripten SDK (which Travis clones to the working directory) have *.in files, and our preprocessor build config is too aggressive about identifying the files to preprocess, finding all *.in files in any subdirectory of the working directory instead of just the PluotSorbet ones. So it preprocesses the Boehm.js and Emscripten ones as well, which may be the reason why tests fail on Travis.

This change explicitly specifies the source files to preprocess, to avoid preprocessing those Boehm.js/Emscripten files. There might be a better glob for this, but this explicit list definitely works. With this change, tests pass on Travis:

```
https://travis-ci.org/mykmelez/pluotsorbet/builds/75976949
```
